### PR TITLE
Remove some duplication in style dictionary build

### DIFF
--- a/utils/style-dictionary.js
+++ b/utils/style-dictionary.js
@@ -11,11 +11,6 @@ module.exports = (source, destinationDir) => {
             options: { showFileHeader: false },
             filter: "omitTypography",
           },
-        ],
-      },
-      scss: {
-        transformGroup: "scss",
-        files: [
           {
             destination: `${destinationDir}/tokens.scss`,
             format: "scss/variables",
@@ -141,21 +136,6 @@ module.exports = (source, destinationDir) => {
     name: "css",
     transforms: [
       // based on https://amzn.github.io/style-dictionary/#/transform_groups?id=css
-      "attribute/cti",
-      "name/cti/kebab",
-      "time/seconds",
-      "content/icon",
-      "size/rem",
-      "color/css",
-      // custom transforms
-      ...customTransforms,
-    ],
-  });
-
-  StyleDictionary.registerTransformGroup({
-    name: "scss",
-    transforms: [
-      // based on https://amzn.github.io/style-dictionary/#/transform_groups?id=scss
       "attribute/cti",
       "name/cti/kebab",
       "time/seconds",


### PR DESCRIPTION
The `css` and `scss` transform groups are identical so I removed the `scss` one. Also removed the scss platform and replaced it by adding an additional file output to the css platform.

The resulting `dist` output is identical

We probably don't even need `scss` but no harm keeping it, especially with this pull request it is just an extension of the css config