### PR TITLE
Update style dictionary platform names

### DIFF
--- a/utils/style-dictionary.js
+++ b/utils/style-dictionary.js
@@ -2,7 +2,7 @@ module.exports = (source, destinationDir) => {
   const StyleDictionary = require("style-dictionary").extend({
     source: [source],
     platforms: {
-      css: {
+      "web/css": {
         transformGroup: "css",
         files: [
           {
@@ -19,7 +19,7 @@ module.exports = (source, destinationDir) => {
           },
         ],
       },
-      js: {
+      "web/js": {
         transformGroup: "js",
         files: [
           {


### PR DESCRIPTION
After reading more into the docs I believe the platform keys should _probably_ map to actual platform names e.g. web, android, ios...